### PR TITLE
Feature: Programatic access to selection mode

### DIFF
--- a/core/api/android/core.api
+++ b/core/api/android/core.api
@@ -4,6 +4,7 @@ public final class com/dragselectcompose/core/DragSelectState {
 	public fun <init> (Ljava/util/List;Landroidx/compose/foundation/lazy/grid/LazyGridState;Lkotlin/jvm/functions/Function1;Lcom/dragselectcompose/core/DragState;)V
 	public final fun addSelected (Ljava/lang/Object;)V
 	public final fun clear ()V
+	public final fun disableSelectionMode ()V
 	public final fun enableSelectionMode ()V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getGridState ()Landroidx/compose/foundation/lazy/grid/LazyGridState;
@@ -12,6 +13,7 @@ public final class com/dragselectcompose/core/DragSelectState {
 	public fun hashCode ()I
 	public final fun isSelected (Ljava/lang/Object;)Z
 	public final fun removeSelected (Ljava/lang/Object;)V
+	public final fun toggleSelectionMode ()V
 	public final fun updateSelected (Ljava/util/List;)V
 }
 

--- a/core/api/android/core.api
+++ b/core/api/android/core.api
@@ -4,6 +4,7 @@ public final class com/dragselectcompose/core/DragSelectState {
 	public fun <init> (Ljava/util/List;Landroidx/compose/foundation/lazy/grid/LazyGridState;Lkotlin/jvm/functions/Function1;Lcom/dragselectcompose/core/DragState;)V
 	public final fun addSelected (Ljava/lang/Object;)V
 	public final fun clear ()V
+	public final fun enableSelectionMode ()V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getGridState ()Landroidx/compose/foundation/lazy/grid/LazyGridState;
 	public final fun getInSelectionMode ()Z
@@ -22,6 +23,8 @@ public final class com/dragselectcompose/core/DragSelectStateKt {
 public final class com/dragselectcompose/core/DragState {
 	public static final field $stable I
 	public fun <init> (II)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
 }
 
 public final class com/dragselectcompose/core/GridDragSelectDefaults {

--- a/core/api/desktop/core.api
+++ b/core/api/desktop/core.api
@@ -4,6 +4,7 @@ public final class com/dragselectcompose/core/DragSelectState {
 	public fun <init> (Ljava/util/List;Landroidx/compose/foundation/lazy/grid/LazyGridState;Lkotlin/jvm/functions/Function1;Lcom/dragselectcompose/core/DragState;)V
 	public final fun addSelected (Ljava/lang/Object;)V
 	public final fun clear ()V
+	public final fun disableSelectionMode ()V
 	public final fun enableSelectionMode ()V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getGridState ()Landroidx/compose/foundation/lazy/grid/LazyGridState;
@@ -12,6 +13,7 @@ public final class com/dragselectcompose/core/DragSelectState {
 	public fun hashCode ()I
 	public final fun isSelected (Ljava/lang/Object;)Z
 	public final fun removeSelected (Ljava/lang/Object;)V
+	public final fun toggleSelectionMode ()V
 	public final fun updateSelected (Ljava/util/List;)V
 }
 

--- a/core/api/desktop/core.api
+++ b/core/api/desktop/core.api
@@ -4,6 +4,7 @@ public final class com/dragselectcompose/core/DragSelectState {
 	public fun <init> (Ljava/util/List;Landroidx/compose/foundation/lazy/grid/LazyGridState;Lkotlin/jvm/functions/Function1;Lcom/dragselectcompose/core/DragState;)V
 	public final fun addSelected (Ljava/lang/Object;)V
 	public final fun clear ()V
+	public final fun enableSelectionMode ()V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getGridState ()Landroidx/compose/foundation/lazy/grid/LazyGridState;
 	public final fun getInSelectionMode ()Z
@@ -22,6 +23,8 @@ public final class com/dragselectcompose/core/DragSelectStateKt {
 public final class com/dragselectcompose/core/DragState {
 	public static final field $stable I
 	public fun <init> (II)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
 }
 
 public final class com/dragselectcompose/core/GridDragSelectDefaults {

--- a/core/src/commonMain/kotlin/com/dragselectcompose/core/DragSelectState.kt
+++ b/core/src/commonMain/kotlin/com/dragselectcompose/core/DragSelectState.kt
@@ -104,12 +104,14 @@ public class DragSelectState<Item>(
     public val selected: List<Item>
         get() = selectedState
 
+    private var manualSelectionMode: Boolean by mutableStateOf(false)
+
     /**
      * Whether or not the grid is in selection mode.
      */
     @Stable
     public val inSelectionMode: Boolean
-        get() = selectedState.isNotEmpty()
+        get() = manualSelectionMode || selectedState.isNotEmpty()
 
     internal val autoScrollSpeed = mutableStateOf(0f)
 
@@ -132,6 +134,12 @@ public class DragSelectState<Item>(
     internal fun startDrag(item: Item, index: Int) {
         dragState = DragState(initial = index, current = index)
         addSelected(item)
+    }
+
+    public fun enableSelectionMode() {
+        if (selectedState.isEmpty()) {
+            manualSelectionMode = true
+        }
     }
 
     /**
@@ -168,6 +176,10 @@ public class DragSelectState<Item>(
      */
     public fun removeSelected(item: Item) {
         selectedState -= item
+
+        if (selectedState.isEmpty() && manualSelectionMode) {
+            manualSelectionMode = false
+        }
     }
 
     /**
@@ -175,6 +187,7 @@ public class DragSelectState<Item>(
      */
     public fun clear() {
         selectedState = emptyList()
+        manualSelectionMode = false
     }
 
     /**

--- a/core/src/commonMain/kotlin/com/dragselectcompose/core/DragSelectState.kt
+++ b/core/src/commonMain/kotlin/com/dragselectcompose/core/DragSelectState.kt
@@ -68,6 +68,7 @@ public fun <Item> rememberDragSelectState(
  * @param[dragState] The current drag state.
  * @param[compareSelector] A factory for selecting a property of [Item] to compare.
  */
+@Suppress("MemberVisibilityCanBePrivate")
 @Stable
 public class DragSelectState<Item>(
     initialSelection: List<Item>,
@@ -136,10 +137,29 @@ public class DragSelectState<Item>(
         addSelected(item)
     }
 
+    /**
+     * Enables selection mode with no items selected.
+     */
     public fun enableSelectionMode() {
         if (selectedState.isEmpty()) {
             manualSelectionMode = true
         }
+    }
+
+    /**
+     * Disables selection mode and clear selected items.
+     */
+    public fun disableSelectionMode() {
+        selectedState = emptyList()
+        manualSelectionMode = false
+    }
+
+    /**
+     * Toggle the selection mode.
+     */
+    public fun toggleSelectionMode() {
+        if (inSelectionMode) disableSelectionMode()
+        else enableSelectionMode()
     }
 
     /**
@@ -158,6 +178,10 @@ public class DragSelectState<Item>(
      */
     public fun updateSelected(selected: List<Item>) {
         selectedState = selected
+
+        if (selectedState.isEmpty() && manualSelectionMode) {
+            manualSelectionMode = false
+        }
     }
 
     /**
@@ -185,9 +209,13 @@ public class DragSelectState<Item>(
     /**
      * Clears the selected items.
      */
+    @Deprecated(
+        message = "Use disableSelectionMode() instead. Will be removed in future version.",
+        replaceWith = ReplaceWith("disableSelectionMode()"),
+        level = DeprecationLevel.WARNING,
+    )
     public fun clear() {
-        selectedState = emptyList()
-        manualSelectionMode = false
+        disableSelectionMode()
     }
 
     /**

--- a/core/src/commonMain/kotlin/com/dragselectcompose/core/DragSelectState.kt
+++ b/core/src/commonMain/kotlin/com/dragselectcompose/core/DragSelectState.kt
@@ -126,12 +126,11 @@ public class DragSelectState<Item>(
     }
 
     internal fun updateDrag(current: Int) {
-        dragState.current = current
+        dragState = dragState.copy(current = current)
     }
 
     internal fun startDrag(item: Item, index: Int) {
-        dragState.initial = index
-        dragState.current = index
+        dragState = DragState(initial = index, current = index)
         addSelected(item)
     }
 
@@ -182,7 +181,7 @@ public class DragSelectState<Item>(
      * Resets the drag state.
      */
     internal fun stopDrag() {
-        dragState.initial = DragState.None
+        dragState = dragState.copy(initial = DragState.None)
         autoScrollSpeed.value = 0f
     }
 

--- a/core/src/commonMain/kotlin/com/dragselectcompose/core/DragState.kt
+++ b/core/src/commonMain/kotlin/com/dragselectcompose/core/DragState.kt
@@ -1,5 +1,6 @@
 package com.dragselectcompose.core
 
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.saveable.Saver
 
 /**
@@ -8,13 +9,34 @@ import androidx.compose.runtime.saveable.Saver
  * @param[initial] The index of the item where the drag gesture started.
  * @param[current] The index of the item where the drag gesture is currently at.
  */
+@Stable
 public class DragState(
-    internal var initial: Int,
-    internal var current: Int,
+    internal val initial: Int,
+    internal val current: Int,
 ) {
 
     internal val isDragging: Boolean
         get() = initial != None && current != None
+
+    internal fun copy(initial: Int = this.initial, current: Int = this.current): DragState {
+        return DragState(initial = initial, current = current)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as DragState
+
+        if (initial != other.initial) return false
+        return current == other.current
+    }
+
+    override fun hashCode(): Int {
+        var result = initial
+        result = 31 * result + current
+        return result
+    }
 
     internal companion object {
 
@@ -27,7 +49,7 @@ public class DragState(
 
         internal val Saver = Saver<DragState, Pair<Int, Int>>(
             save = { it.initial to it.current },
-            restore = { (initial, current) -> create(initial = initial, current = current) }
+            restore = { (initial, current) -> DragState(initial = initial, current = current) },
         )
     }
 }

--- a/demo/kmm/shared/src/commonMain/kotlin/com/dragselectcompose/demo/App.kt
+++ b/demo/kmm/shared/src/commonMain/kotlin/com/dragselectcompose/demo/App.kt
@@ -38,8 +38,7 @@ fun App() {
                     actions = {
                         Button(
                             onClick = {
-                                if (dragSelectState.inSelectionMode) dragSelectState.clear()
-                                else dragSelectState.enableSelectionMode()
+                                dragSelectState.toggleSelectionMode()
                             },
                         ) {
                             val text = if (dragSelectState.inSelectionMode) "Cancel" else "Select"

--- a/demo/kmm/shared/src/commonMain/kotlin/com/dragselectcompose/demo/App.kt
+++ b/demo/kmm/shared/src/commonMain/kotlin/com/dragselectcompose/demo/App.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ClearAll
 import androidx.compose.material.icons.outlined.CopyAll
+import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -35,6 +36,16 @@ fun App() {
                         }
                     },
                     actions = {
+                        Button(
+                            onClick = {
+                                if (dragSelectState.inSelectionMode) dragSelectState.clear()
+                                else dragSelectState.enableSelectionMode()
+                            },
+                        ) {
+                            val text = if (dragSelectState.inSelectionMode) "Cancel" else "Select"
+                            Text(text = text)
+                        }
+
                         IconButton(onClick = { dragSelectState.updateSelected(items) }) {
                             Icon(
                                 imageVector = Icons.Outlined.CopyAll,


### PR DESCRIPTION
Resolves #43 

- Add three selection mode functions
    - `enableSelectionMode()`
    - `disableSelectionMode()`
    - `toggleSelectionMode()`: Combines the two above
- Deprecate the `clear()` function in favour of `disableSelectionMode()`