### PR TITLE
Fix selection failed to work when the item list object changes

### DIFF
--- a/core/src/commonMain/kotlin/com/dragselectcompose/core/GridDragSelect.kt
+++ b/core/src/commonMain/kotlin/com/dragselectcompose/core/GridDragSelect.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.geometry.Offset
@@ -71,11 +73,13 @@ public fun <Item> Modifier.gridDragSelect(
         if (!enableHaptics) null
         else hapticFeedback ?: GridDragSelectDefaults.hapticsFeedback
 
+    val currentItems by rememberUpdatedState(items)
+
     pointerInput(Unit) {
         detectDragGesturesAfterLongPress(
             onDragStart = { offset ->
                 state.gridState.itemIndexAtPosition(offset)?.let { startIndex ->
-                    val item = items.getOrNull(startIndex)
+                    val item = currentItems.getOrNull(startIndex)
                     if (item != null && state.selected.contains(item).not()) {
                         haptics?.performHapticFeedback(HapticFeedbackType.LongPress)
                         state.startDrag(item, startIndex)
@@ -92,7 +96,7 @@ public fun <Item> Modifier.gridDragSelect(
                         ?: return@whenDragging
 
                     val newSelection =
-                        items.getSelectedItems(itemPosition, dragState, state::isSelected)
+                        currentItems.getSelectedItems(itemPosition, dragState, state::isSelected)
 
                     updateDrag(current = itemPosition)
                     updateSelected(newSelection)


### PR DESCRIPTION
The block of `pointerInput(Unit)` captures the `items` parameter, which is the data source object. When data source object changed to different one, the `LazyGrid` composable will be re-composed, but the previous block of `pointerInput(Unit)` won't be cancelled because it specifies a key of `Unit`. So block could use the old data source object previously captured, and that causes unexpected behavior.

`pointerInput` function's doc also explained this issue and gives 2 ways to resolve.
![image](https://github.com/user-attachments/assets/77afc2dd-c6d8-4eb9-9f54-310ff9abedb3)


This PR follows the [suggestions/samples](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/ui/ui/samples/src/main/java/androidx/compose/ui/samples/PointerInputModifierSamples.kt) to use `rememberUpdatedState` to make sure the data is always up-to-date.